### PR TITLE
Microphone.GetPosition(device.name)が成功しないときにフリーズする不具合を修正

### DIFF
--- a/Assets/uLipSync/Scripts/uLipSyncMicrophone.cs
+++ b/Assets/uLipSync/Scripts/uLipSyncMicrophone.cs
@@ -1,4 +1,5 @@
-﻿using UnityEngine;
+﻿using System.Collections;
+using UnityEngine;
 
 namespace uLipSync
 {
@@ -61,7 +62,7 @@ public class uLipSyncMicrophone : MonoBehaviour
         if (isStartRequested)
         {
             isStartRequested = false;
-            StartRecordInternal();
+            StartCoroutine(StartRecordInternal());
         }
 
         if (isStopRequested)
@@ -109,15 +110,22 @@ public class uLipSyncMicrophone : MonoBehaviour
         isStartRequested = false;
     }
 
-    void StartRecordInternal()
+    IEnumerator StartRecordInternal()
     {
-        if (!source) return;
+        if (!source) yield break;
 
         int freq = maxFreq;
         if (freq <= 0) freq = 48000;
 
         clip = Microphone.Start(device.name, true, 10, freq);
-        while (Microphone.GetPosition(device.name) <= 0) ;
+        for(int i=0; Microphone.GetPosition(device.name) <= 0; i++){
+            if(i > 100)
+            {
+                Debug.LogError("Failed to get microphone.");
+                yield break;
+            }
+            yield return null;
+        }
         source.loop = true;
         source.Play();
 


### PR DESCRIPTION
こんにちは。
uLipSyncMicrophone.csにて、Microphone.GetPosition(device.name)が成功しない（戻り値か1以上にならない）ときに無限ループになってUnityごとフリーズする不具合がありましたので修正案のpull requestを送らせていただきます。
フリーズする現象は、自分の場合はNDI tools（ https://tricaster.jp/ndi-central/ndi-tools ）のNewTek NDI Audioがマイク入力になっているときに起きました。おそらく仮想オーディオデバイスが入力として与えられたときにMicrophone.GetPosition(device.name)が成功しない場合があるのだと思います。
とりあえずMicrophone.GetPosition(device.name)が100フレーム待っても成功しない場合はループから抜ける実装に変えることで自分の環境ではフリーズしないようになりました。100フレームなのは特に根拠はありません。
他にもフリーズして困っている方がいるかと思いとりあえずこのpull requestを送らせていただきました。よろしくお願いします。