### PR TITLE
Make it possible to receive audio data from other scripts #11

### DIFF
--- a/Assets/uLipSync/Runtime/uLipSync.cs
+++ b/Assets/uLipSync/Runtime/uLipSync.cs
@@ -214,7 +214,7 @@ public class uLipSync : MonoBehaviour
         currentAudioSource_ = audioSource;
     }
 
-    void OnDataReceived(float[] input, int channels)
+    public void OnDataReceived(float[] input, int channels)
     {
         if (rawInputData_ == null || rawInputData_.Length == 0) return;
 


### PR DESCRIPTION
In some cases `MonoBehaviour.OnAudioFilterRead()` doesn't work. This change provides the alternative way for such cases.

But honestly I'm not sure that this change is align with principles of overall architecture design. It may make testing complex.
If you don't like it, it's okay to reject it for any reasons.👍