### PR TITLE
Some values in Profile are not saved in some cases

### DIFF
--- a/Assets/uLipSync/Editor/ProfileEditor.cs
+++ b/Assets/uLipSync/Editor/ProfileEditor.cs
@@ -144,7 +144,13 @@ public class ProfileEditor : Editor
         if (!EditorUtil.SimpleFoldout(position, data.name, true, "MfccData")) return;
         position.y += EditorUtil.lineHeightWithMargin;
 
-        data.name = EditorGUI.TextField(position, "Phoneme", data.name);
+        var newName = EditorGUI.TextField(position, "Phoneme", data.name);
+        if (newName != data.name)
+        {
+            Undo.RecordObject(target, "Change Phoneme");
+            data.name = newName;
+            EditorUtility.SetDirty(target);
+        }
         position.y += EditorUtil.lineHeightWithMargin;
         position.y += 5f;
 
@@ -219,7 +225,13 @@ public class ProfileEditor : Editor
     void DrawImportExport()
     {
         EditorGUILayout.BeginHorizontal();
-        profile.jsonPath = EditorGUILayout.TextField("File Path", profile.jsonPath);
+        var newJsonPath = EditorGUILayout.TextField("File Path", profile.jsonPath);
+        if (newJsonPath != profile.jsonPath)
+        {
+            Undo.RecordObject(target, "Change File Path");
+            profile.jsonPath = newJsonPath;
+            EditorUtility.SetDirty(target);
+        }
         if (GUILayout.Button("...", EditorStyles.miniButton, GUILayout.Width(24)))
         {
             try

--- a/Assets/uLipSync/Editor/ProfileEditor.cs
+++ b/Assets/uLipSync/Editor/ProfileEditor.cs
@@ -34,10 +34,17 @@ public class ProfileEditor : Editor
 
         if (EditorUtil.SimpleFoldout("MFCC", true, "-uLipSync-Profile"))
         {
+            EditorGUI.BeginChangeCheck();
+            
             ++EditorGUI.indentLevel;
             CalcMinMax();
             DrawMfccReorderableList(showCalibration);
             --EditorGUI.indentLevel;
+            
+            if (EditorGUI.EndChangeCheck())
+            {
+                EditorUtility.SetDirty(target);
+            }
         }
 
         if (EditorUtil.SimpleFoldout("Advanced Parameters", true, "-uLipSync-Profile"))


### PR DESCRIPTION
There was a bug in the editor extension of Profile that the following values were not saved.
If restart the editor after changing these values, the values may not be saved.

* `MFCC` -> `MFCCs` -> `Phoneme`
* `Import /Export Json` -> `File Path`
* `MFCC` -> `MFCCs`

For Phoneme and File Path, I added the process of registering to Undo and calling SetDirty after changing the value.
For each element of MFCCs, I added only calling SetDirty after the property is changed, because it would require a large modification to implement Undo for detailed processing.

Reference page for Undo.RecordObject and EditorUtility.SetDirty : [EditorUtility.SetDirty Broken? - Unity Forum](https://forum.unity.com/threads/editorutility-setdirty-broken.375344/)