### PR TITLE
モノラル以外の音声をベイクする際のバグを修正

### DIFF
--- a/Assets/uLipSync/Editor/BakedDataEditor.cs
+++ b/Assets/uLipSync/Editor/BakedDataEditor.cs
@@ -1,4 +1,5 @@
-﻿using UnityEngine;
+﻿using System;
+using UnityEngine;
 using UnityEditor;
 using System.Text;
 using System.Collections.Generic;
@@ -244,7 +245,8 @@ public class BakedDataEditor : Editor
 
         var clip = data.audioClip;
         int samplePerFrame = clip.frequency / 60 * clip.channels;
-        var buf = new float[samplePerFrame];
+        var buffer = new float[clip.samples * clip.channels];
+        var tempBuffer = new float[samplePerFrame];
 
         data.duration = clip.length;
 
@@ -252,10 +254,12 @@ public class BakedDataEditor : Editor
         var ls = go.AddComponent<uLipSync>();
         ls.OnBakeStart(data.profile);
 
-        for (int offset = 0; offset < clip.samples; offset += samplePerFrame)
+        clip.GetData(buffer, 0);
+
+        for (int offset = 0; offset < buffer.Length - samplePerFrame; offset += samplePerFrame)
         {
-            clip.GetData(buf, offset);
-            ls.OnBakeUpdate(buf, clip.channels);
+            Array.Copy(buffer, offset, tempBuffer, 0, samplePerFrame);
+            ls.OnBakeUpdate(tempBuffer, clip.channels);
 
             var frame = new BakedFrame();
             frame.volume = ls.result.rawVolume;


### PR DESCRIPTION
# 概要
モノラル以外の音声から作成されたBaked Dataを再生すると、倍速でリップシンクが再生されてしまうバグを修正しました。
一度全てのサンプルをバッファに格納して、随時1/60秒分のバッファをコピーする方式に変更しました。

# 詳細
`AudioClip.GetData()`からサンプルを取得する場合は`clip.samples * clip.channels`分のバッファを用意する必要がありますが、ベイクをするループではチャンネル数が考慮されていませんでした。
参照 : [AudioClip.GetData](https://docs.unity3d.com/jp/current/ScriptReference/AudioClip.GetData.html)
```cs
for (int offset = 0; offset < clip.samples; offset += samplePerFrame)
```

以下のように変更することで全てのサンプルを取得できるようになります。
```cs
for (int offset = 0; offset < clip.samples * clip.channels; offset += samplePerFrame)
```

ですが、この方法で実装した場合、取得するサンプルが全体の半分を超えた辺りで以下のようなエラーが出てしまいます。
```
C:/buildslave/unity/build/Runtime/Audio/sound/SoundManager.cpp(540) : Error executing instance->m_Sound->unlock(ptr1, ptr2, len1, len2) (An invalid parameter was passed to this function. )
UnityEngine.AudioClip:GetData(Single[], Int32)
```

このエラーは[こちら](https://forum.unity.com/threads/error-executing-instance-m_sound-unlock.339658/)でも取り上げられている通り、根本的な原因は分かっていませんが代替案として一度全てのサンプルをバッファに格納するという方法が提案されています。

この代替案を元に処理を書き換えたところ、正しく動作することが確認できました。