### PR TITLE
リップシンクをアップデートするタイミングを変更できるように

### DIFF
--- a/Assets/uLipSync/Editor/uLipSyncBlendShapeEditor.cs
+++ b/Assets/uLipSync/Editor/uLipSyncBlendShapeEditor.cs
@@ -16,6 +16,14 @@ public class uLipSyncBlendShapeEditor : Editor
     public override void OnInspectorGUI()
     {
         serializedObject.Update();
+        
+        if (EditorUtil.Foldout("LipSync Update Method", true))
+        {
+            ++EditorGUI.indentLevel;
+            EditorUtil.DrawProperty(serializedObject, nameof(blendShape.updateMethod));
+            --EditorGUI.indentLevel;
+            EditorGUILayout.Separator();
+        }
 
         if (EditorUtil.Foldout("Skinned Mesh Renderer", true))
         {

--- a/Assets/uLipSync/Runtime/Core/Common.cs
+++ b/Assets/uLipSync/Runtime/Core/Common.cs
@@ -31,4 +31,13 @@ public class AudioFilterReadEvent : UnityEvent<float[], int>
 {
 }
 
+public enum UpdateMethod
+{
+    LateUpdate,
+    Update,
+    FixedUpdate,
+    LipSyncUpdateEvent,
+    External,
+}
+
 }

--- a/Assets/uLipSync/Runtime/uLipSyncBlendShape.cs
+++ b/Assets/uLipSync/Runtime/uLipSyncBlendShape.cs
@@ -18,6 +18,7 @@ public class uLipSyncBlendShape : MonoBehaviour
         public float weightVelocity { get; set; } = 0f;
     }
 
+    public UpdateMethod updateMethod = UpdateMethod.LateUpdate;
     public SkinnedMeshRenderer skinnedMeshRenderer;
     public List<BlendShapeInfo> blendShapes = new List<BlendShapeInfo>();
     public float minVolume = -2.5f;
@@ -39,6 +40,13 @@ public class uLipSyncBlendShape : MonoBehaviour
     {
         _info = info;
         _lipSyncUpdated = true;
+        if (updateMethod == UpdateMethod.LipSyncUpdateEvent)
+        {
+            UpdateVolume();
+            UpdateVowels();
+            _lipSyncUpdated = false;
+            LateUpdateBlendShapes();
+        }
     }
 
     void Update()
@@ -46,9 +54,17 @@ public class uLipSyncBlendShape : MonoBehaviour
 #if UNITY_EDITOR
         if (_isAnimationBaking) return;
 #endif
-        UpdateVolume();
-        UpdateVowels();
-        _lipSyncUpdated = false;
+        if (updateMethod != UpdateMethod.LipSyncUpdateEvent)
+        {
+            UpdateVolume();
+            UpdateVowels();
+            _lipSyncUpdated = false;
+        }
+
+        if (updateMethod == UpdateMethod.Update)
+        {
+            LateUpdateBlendShapes();
+        }
     }
 
     void LateUpdate()
@@ -56,7 +72,21 @@ public class uLipSyncBlendShape : MonoBehaviour
 #if UNITY_EDITOR
         if (_isAnimationBaking) return;
 #endif
-        LateUpdateBlendShapes();
+        if (updateMethod == UpdateMethod.LateUpdate)
+        {
+            LateUpdateBlendShapes();
+        }
+    }
+
+    void FixedUpdate()
+    {
+#if UNITY_EDITOR
+        if (_isAnimationBaking) return;
+#endif
+        if (updateMethod == UpdateMethod.FixedUpdate)
+        {
+            LateUpdateBlendShapes();
+        }
     }
 
     float SmoothDamp(float value, float target, ref float velocity)
@@ -108,6 +138,14 @@ public class uLipSyncBlendShape : MonoBehaviour
         }
     }
 
+    public void ApplyBlendShapes()
+    {
+        if (updateMethod == UpdateMethod.External)
+        {
+            LateUpdateBlendShapes();
+        }
+    }
+    
     protected virtual void LateUpdateBlendShapes()
     {
         if (!skinnedMeshRenderer) return;

--- a/Assets/uLipSync/Runtime/uLipSyncBlendShape.cs
+++ b/Assets/uLipSync/Runtime/uLipSyncBlendShape.cs
@@ -1,3 +1,4 @@
+using System;
 using UnityEngine;
 using System.Collections.Generic;
 
@@ -136,6 +137,11 @@ public class uLipSyncBlendShape : MonoBehaviour
         {
             bs.weight = sum > 0f ? bs.weight / sum : 0f;
         }
+    }
+    
+    [Obsolete("Use OnApplyBlendShapes", true)]
+    protected virtual void LateUpdateBlendShapes()
+    {
     }
 
     public void ApplyBlendShapes()

--- a/Assets/uLipSync/Runtime/uLipSyncBlendShape.cs
+++ b/Assets/uLipSync/Runtime/uLipSyncBlendShape.cs
@@ -1,4 +1,3 @@
-using System;
 using UnityEngine;
 using System.Collections.Generic;
 
@@ -137,11 +136,6 @@ public class uLipSyncBlendShape : MonoBehaviour
         {
             bs.weight = sum > 0f ? bs.weight / sum : 0f;
         }
-    }
-    
-    [Obsolete("Use OnApplyBlendShapes", true)]
-    protected virtual void LateUpdateBlendShapes()
-    {
     }
 
     public void ApplyBlendShapes()

--- a/Assets/uLipSync/Runtime/uLipSyncBlendShape.cs
+++ b/Assets/uLipSync/Runtime/uLipSyncBlendShape.cs
@@ -45,7 +45,7 @@ public class uLipSyncBlendShape : MonoBehaviour
             UpdateVolume();
             UpdateVowels();
             _lipSyncUpdated = false;
-            LateUpdateBlendShapes();
+            OnApplyBlendShapes();
         }
     }
 
@@ -63,7 +63,7 @@ public class uLipSyncBlendShape : MonoBehaviour
 
         if (updateMethod == UpdateMethod.Update)
         {
-            LateUpdateBlendShapes();
+            OnApplyBlendShapes();
         }
     }
 
@@ -74,7 +74,7 @@ public class uLipSyncBlendShape : MonoBehaviour
 #endif
         if (updateMethod == UpdateMethod.LateUpdate)
         {
-            LateUpdateBlendShapes();
+            OnApplyBlendShapes();
         }
     }
 
@@ -85,7 +85,7 @@ public class uLipSyncBlendShape : MonoBehaviour
 #endif
         if (updateMethod == UpdateMethod.FixedUpdate)
         {
-            LateUpdateBlendShapes();
+            OnApplyBlendShapes();
         }
     }
 
@@ -142,11 +142,11 @@ public class uLipSyncBlendShape : MonoBehaviour
     {
         if (updateMethod == UpdateMethod.External)
         {
-            LateUpdateBlendShapes();
+            OnApplyBlendShapes();
         }
     }
     
-    protected virtual void LateUpdateBlendShapes()
+    protected virtual void OnApplyBlendShapes()
     {
         if (!skinnedMeshRenderer) return;
 

--- a/Assets/uLipSync/Samples/04. VRM/Editor/uLipSyncBlendShapeVRMEditor.cs
+++ b/Assets/uLipSync/Samples/04. VRM/Editor/uLipSyncBlendShapeVRMEditor.cs
@@ -24,6 +24,14 @@ public class uLipSyncBlendShapeVRMEditor : uLipSyncBlendShapeEditor
     public override void OnInspectorGUI()
     {
         serializedObject.Update();
+        
+        if (EditorUtil.Foldout("LipSync Update Method", true))
+        {
+            ++EditorGUI.indentLevel;
+            EditorUtil.DrawProperty(serializedObject, nameof(blendShape.updateMethod));
+            --EditorGUI.indentLevel;
+            EditorGUILayout.Separator();
+        }
 
         if (EditorUtil.Foldout("Parameters", true))
         {

--- a/Assets/uLipSync/Samples/04. VRM/Runtime/uLipSyncBlendShapeVRM.cs
+++ b/Assets/uLipSync/Samples/04. VRM/Runtime/uLipSyncBlendShapeVRM.cs
@@ -8,7 +8,7 @@ namespace uLipSync
 [RequireComponent(typeof(VRMBlendShapeProxy))]
 public class uLipSyncBlendShapeVRM : uLipSyncBlendShape
 {
-    protected override void LateUpdateBlendShapes()
+    protected override void OnApplyBlendShapes()
     {
         var proxy = GetComponent<VRMBlendShapeProxy>();
         if (!proxy) return;


### PR DESCRIPTION
# 概要
リップシンクをアップデートするタイミングを変更できるようにしました。
これにより、別のトラックからのリップシンクの上書きや外部のスクリプトからの呼び出しに対応できます。
![image](https://user-images.githubusercontent.com/40651807/156512098-58ae65c4-4be1-4909-8f0d-776a634c2196.png)

# 詳細
## UpdateMethod
|名称|説明|
|-|-|
|LateUpdate|従来通りLateUpdateで更新する（互換性を保つためにデフォルトはこれです）|
|Update|Updateで更新する|
|FixedUpdate|FixedUpdateで更新する|
|LipSyncUpdateEvent|LipSyncUpdateEventを受けた直後に更新する|
|External|外部のスクリプトから更新する（`ApplyBlendShapes()`）|

# 問題点
今までは`LateUpdateBlendShapes()`でBlendShapeを更新する処理を書いていましたが、UpdateMethodから変更できるようになったため`OnApplyBlendShapes()`に変更してあります。
[change apply blend shapes method name.](https://github.com/hecomi/uLipSync/commit/708e7e7e814dc6cc2283d0f36ab1ee28bddf6a55)

互換性を優先するために変更をしないというのもアリだと思います。

また、名前を変更する場合`LateUpdateBlendShapes()`を削除するかObsoleteのアトリビュートを付けるかで少し悩んでいます。
[Obsolete("", true)]としてもそのメソッドがvirtualの場合はoverrideをしてもコンパイルエラーを出すことができないためです。
いっそのこと`LateUpdateBlendShapes()`を残さずに`OnApplyBlendShapes()`のみにする方が安全かもしれません。
[add obsolete attribute.](https://github.com/hecomi/uLipSync/commit/810a70a37a909ec35ce7f6a66d7ed89c71cd4955)