### PR TITLE
Add vrm expression sample

### DIFF
--- a/Assets/uLipSync/Samples/04. VRM/Editor/uLipSyncExpressionVRMEditor.cs
+++ b/Assets/uLipSync/Samples/04. VRM/Editor/uLipSyncExpressionVRMEditor.cs
@@ -51,7 +51,7 @@ public class uLipSyncExpressionVRMEditor : uLipSyncBlendShapeEditor
 
     protected override string[] GetBlendShapeArray()
     {
-        if (!vrm10Instance) return new string[] { "" };
+        if (!vrm10Instance || !vrm10Instance.Vrm) return new string[] { "" };
 
         return vrm10Instance.Vrm.Expression.Clips.Select(x => x.Clip.name).ToArray();
     }

--- a/Assets/uLipSync/Samples/04. VRM/Editor/uLipSyncExpressionVRMEditor.cs
+++ b/Assets/uLipSync/Samples/04. VRM/Editor/uLipSyncExpressionVRMEditor.cs
@@ -1,0 +1,60 @@
+using UnityEditor;
+using UnityEditorInternal;
+using System.Linq;
+using UniVRM10;
+using VRM;
+
+namespace uLipSync
+{
+
+[CustomEditor(typeof(uLipSyncExpressionVRM))]
+public class uLipSyncExpressionVRMEditor : uLipSyncBlendShapeEditor
+{
+    uLipSyncExpressionVRM expression { get { return target as uLipSyncExpressionVRM; } }
+    Vrm10Instance vrm10Instance;
+
+    void OnEnable()
+    {
+        vrm10Instance = expression.GetComponent<Vrm10Instance>();
+    }
+
+    public override void OnInspectorGUI()
+    {
+        serializedObject.Update();
+        
+        if (EditorUtil.Foldout("LipSync Update Method", true))
+        {
+            ++EditorGUI.indentLevel;
+            EditorUtil.DrawProperty(serializedObject, nameof(expression.updateMethod));
+            --EditorGUI.indentLevel;
+            EditorGUILayout.Separator();
+        }
+
+        if (EditorUtil.Foldout("Parameters", true))
+        {
+            ++EditorGUI.indentLevel;
+            DrawParameters();
+            --EditorGUI.indentLevel;
+            EditorGUILayout.Separator();
+        }
+
+        if (EditorUtil.Foldout("Blend Shapes", true))
+        {
+            ++EditorGUI.indentLevel;
+            DrawBlendShapeReorderableList();
+            --EditorGUI.indentLevel;
+            EditorGUILayout.Separator();
+        }
+
+        serializedObject.ApplyModifiedProperties();
+    }
+
+    protected override string[] GetBlendShapeArray()
+    {
+        if (!vrm10Instance) return new string[] { "" };
+
+        return vrm10Instance.Vrm.Expression.Clips.Select(x => x.Clip.name).ToArray();
+    }
+}
+
+}

--- a/Assets/uLipSync/Samples/04. VRM/Editor/uLipSyncExpressionVRMEditor.cs.meta
+++ b/Assets/uLipSync/Samples/04. VRM/Editor/uLipSyncExpressionVRMEditor.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3f387d8996b894d4fbcb71af097ca36c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/uLipSync/Samples/04. VRM/Runtime/uLipSyncExpressionVRM.cs
+++ b/Assets/uLipSync/Samples/04. VRM/Runtime/uLipSyncExpressionVRM.cs
@@ -12,7 +12,7 @@ public class uLipSyncExpressionVRM : uLipSyncBlendShape
     protected override void OnApplyBlendShapes()
     {
         var vrm10Instance = GetComponent<Vrm10Instance>();
-        if (!vrm10Instance) return;
+        if (!vrm10Instance || !vrm10Instance.Vrm) return;
 
         var clips = vrm10Instance.Vrm.Expression.Clips.ToArray();
         foreach (var bs in blendShapes)

--- a/Assets/uLipSync/Samples/04. VRM/Runtime/uLipSyncExpressionVRM.cs
+++ b/Assets/uLipSync/Samples/04. VRM/Runtime/uLipSyncExpressionVRM.cs
@@ -1,0 +1,29 @@
+using System.Linq;
+using UnityEngine;
+using UniVRM10;
+
+namespace uLipSync
+{
+
+[ExecuteAlways]
+[RequireComponent(typeof(Vrm10Instance))]
+public class uLipSyncExpressionVRM : uLipSyncBlendShape
+{
+    protected override void OnApplyBlendShapes()
+    {
+        var vrm10Instance = GetComponent<Vrm10Instance>();
+        if (!vrm10Instance) return;
+
+        var clips = vrm10Instance.Vrm.Expression.Clips.ToArray();
+        foreach (var bs in blendShapes)
+        {
+            var index = bs.index + 1;
+            if (index < 0 || index >= clips.Length) continue;
+            var clip = clips[index];
+            var weight = bs.weight * bs.maxWeight * volume;
+            vrm10Instance.Runtime.Expression.SetWeight(new ExpressionKey(clip.Preset, clip.Clip.name), weight);
+        }
+    }
+}
+
+}

--- a/Assets/uLipSync/Samples/04. VRM/Runtime/uLipSyncExpressionVRM.cs.meta
+++ b/Assets/uLipSync/Samples/04. VRM/Runtime/uLipSyncExpressionVRM.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2fecf1a600805b64d8373a3755a41b9f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {fileID: 2800000, guid: e683fd49b7e1a47f1a1681b1b9880c90, type: 3}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## 概要
VRM 1.0のExpressionのサンプルを追加しました。

## 変更箇所
* uLipSyncExpressionVRMを追加
* uLipSyncExpressionVRMEditorを追加

## その他
仮で`Assets/Samples/04. VRM`以下に置いていますが、場合によっては別フォルダを切ってもいいかもしれません。
SampleSceneの追加を考えていましたが、VRM 1.0に対応したモデルがリポジトリに含まれていないため一旦無しにしています。

![image](https://user-images.githubusercontent.com/40651807/198196203-e41889f9-4b6b-4716-882f-969b4578e267.png)