### PR TITLE
Fix microphone desynchronization issues

### DIFF
--- a/Assets/uLipSync/Editor/uLipSyncMicInputEditor.cs
+++ b/Assets/uLipSync/Editor/uLipSyncMicInputEditor.cs
@@ -29,6 +29,8 @@ public class uLipSyncMicrophoneEditor : Editor
     void DrawProps()
     {
         mic.isAutoStart = EditorGUILayout.Toggle("Is Auto Start", mic.isAutoStart);
+        mic.latencyTolerance = EditorGUILayout.DelayedFloatField("Latency Tolerance (s)", mic.latencyTolerance);
+        EditorGUILayout.LabelField("Mic to AudioSource Latency", $"{mic.latency:0.00} s");
         EditorGUILayout.LabelField("Frequency", $"Min: {mic.device.minFreq} Hz / Max: {mic.device.maxFreq} Hz");
         if (Application.isPlaying)
         {

--- a/Assets/uLipSync/Runtime/uLipSyncMicrophone.cs
+++ b/Assets/uLipSync/Runtime/uLipSyncMicrophone.cs
@@ -11,6 +11,7 @@ public class uLipSyncMicrophone : MonoBehaviour
     public int index = 0;
     private int preIndex_ = 0;
     public bool isAutoStart = true;
+    public float latencyTolerance = .05f;
 
     public AudioSource source { get; private set; }
     public bool isReady { get; private set; } = false;
@@ -18,6 +19,7 @@ public class uLipSyncMicrophone : MonoBehaviour
     public bool isStopRequested { get; private set; } = false;
     public bool isRecording { get; private set; } = false;
     public MicDevice device { get; private set; } = new MicDevice();
+    public float latency { get; private set; } = 0;
     public int micFreq { get { return device.minFreq; } }
     public int maxFreq { get { return device.maxFreq; } }
 
@@ -59,6 +61,7 @@ public class uLipSyncMicrophone : MonoBehaviour
     void Update()
     {
         UpdateDevice();
+        CheckLatency();
 
         if (isStartRequested)
         {
@@ -92,6 +95,31 @@ public class uLipSyncMicrophone : MonoBehaviour
         preIndex_ = index;
         StopRecordInternal();
         UpdateMicInfo();
+    }
+
+    void CheckLatency()
+    {
+        if(!isRecording) return; 
+
+        // calculate latency
+        float micTime = Microphone.GetPosition(device.name) / freq;
+        float clipTime = source.time;
+        latency = micTime - clipTime;
+        
+        // handle rollover
+        if(latency < -clip.length / 2) latency += clip.length; 
+
+        if(Mathf.Abs(latency) > latencyTolerance)
+        {
+            Debug.LogWarning($"Microphone and AudioSource went out of sync! ({latency:0.00} s)");
+            
+            // check if the microphone stopped recording. sometimes this is caused by a faulty connection
+            if(Microphone.IsRecording(device.name))
+                source.time = micTime;
+            else
+                StartRecord(); 
+        }
+        // Debug.Log(latency);
     }
 
     public void StartRecord()


### PR DESCRIPTION
### Issue
Sometimes when using `uLipSyncMicrophone` the `Microphone` and `AudioSource` become out of sync.
One way to reproduce this problem is to pause the editor while the scene is running.
This results in a delay between spoken words and detection.
Similar problems can occur when the microphone is momentarily disconnected due to a bad cable or buggy drivers.

### Changes
- Set `AudioSource` playback position to `Microphone` playback position when they become out of sync
- Restart `Microphone` if it stops recording while `isRecording` is true

---
Thank you hecomi for this amazing library!
I like it very much.