### PR TITLE
BakedDataの変更が保存されない問題を修正

### DIFF
--- a/Assets/uLipSync/Editor/BakedDataEditor.cs
+++ b/Assets/uLipSync/Editor/BakedDataEditor.cs
@@ -284,6 +284,9 @@ public class BakedDataEditor : Editor
 
         ls.OnBakeEnd();
         DestroyImmediate(go);
+        
+        EditorUtility.SetDirty(data);
+        AssetDatabase.SaveAssets();
     }
 }
 


### PR DESCRIPTION
## 概要
BakedDataの変更（bakedProfile, bakedAudioClip, duration, frames）が保存されないことがあるため、`BakedDataEditor.Bake()`の最後に変更を保存する処理を追加しました。

## 再現方法
1. Baked Dataを作成
![image](https://github.com/hecomi/uLipSync/assets/40651807/137c7752-4d06-4861-90de-bf2089449018)
2. Baked DataをuLipSyncTrackに追加
![image](https://github.com/hecomi/uLipSync/assets/40651807/25567e71-39df-4052-8fb6-e82d48256b96)
3. Baked DataのProfileとAudio Clipに任意のアセットを設定
![image](https://github.com/hecomi/uLipSync/assets/40651807/a205f9ab-0ca1-4da0-a9bb-53a28fa85ad1)
4. Unityを閉じる
（もし、ここでUnityを閉じる前にBakeを行えばタイムラインの変更保存時に同時にBakedDataの変更も保存されます）
5. タイムラインの変更を保存
![image](https://github.com/hecomi/uLipSync/assets/40651807/67df35d0-b3cf-4646-bbf4-b1006f1422c7)
6. Unityを開く
7. Bakeボタンを押す
この時点では正しく動作します
![image](https://github.com/hecomi/uLipSync/assets/40651807/22d41e76-940f-438e-9bd3-f42cc0ee5cec)
8. Unityを閉じる
閉じる前にCtrl+SをしてもBakedDataの変更は保存されません
9. Unityを開く
10. Baked Dataが反映されていない
![image](https://github.com/hecomi/uLipSync/assets/40651807/dc0630d1-b191-4f68-8c7e-a0e465c3d8b4)
![image](https://github.com/hecomi/uLipSync/assets/40651807/e8ca6ddd-2bce-4033-a227-666a0c0ee29d)