### PR TITLE
長尺の音声をベイクすると"Hold on"でハングする問題を修正

### DIFF
--- a/Assets/uLipSync/Editor/BakedDataEditor.cs
+++ b/Assets/uLipSync/Editor/BakedDataEditor.cs
@@ -178,9 +178,10 @@ public class BakedDataEditor : Editor
 
         for (int j = 0; j < phonemeCount; ++j)
         {
-            var points = new Vector3[n];
+            var pointsCount = Mathf.Min(n, maxN);
+            var points = new Vector3[pointsCount];
 
-            for (int i = 0; i < n; ++i)
+            for (int i = 0; i < pointsCount; ++i)
             {
                 var index = Mathf.Min(i * skip, data.frames.Count - 1);
                 var frame = data.frames[index];


### PR DESCRIPTION
## 概要
長尺（10分以上？）の音声のBakedDataをベイクすると"Hold on"が表示されたままになる問題を修正しました。

## 変更内容
* Baked DataのDataに表示されるグラフのPhonemeごとのフレーム数が512個を超えないように処理を変更
恐らく、このPRで書いた処理内容が本来意図されていたものかと思います。

## 詳細
Handles.DrawAAPolyLine()に渡すポイントの数が大きくなると"Hold on"が表示されたままになるようでした。
具体的なポイントの数は状況によって前後するため不明ですが、大体80kを超えるとハングしやすくなります。
（Handles.DrawAAPolyLineの挙動に関してはUnityにバグレポートを送信済みです）

![image](https://github.com/hecomi/uLipSync/assets/40651807/69fc3a57-5cea-471c-84a2-713e82450592)
