### PR TITLE
Better Directory Input & Game Object based Lip Syncing

### DIFF
--- a/Assets/uLipSync/Editor/BakedDataWizard.cs
+++ b/Assets/uLipSync/Editor/BakedDataWizard.cs
@@ -1,0 +1,191 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using UnityEditor;
+using uLipSync;
+using UnityEngine;
+
+///
+/
+///
+public class BakedDataWizard : ScriptableWizard
+{
+    SerializedObject _serializedObject;
+
+    [SerializeField]
+    Profile profile;
+    [SerializeField]
+    string inputDirectory = "";
+    [SerializeField]
+    string outputDirectory = "";
+    
+    StringBuilder _message = new();
+    
+    [MenuItem("Window/uLipSync/Baked Data Wizard")]
+    static void Open()
+    {
+        DisplayWizard<BakedDataWizard>("Baked Data Directory Mirror Generator", "Generate");
+    }
+
+    protected override bool DrawWizardGUI()
+    {
+        _serializedObject ??= new SerializedObject(this);
+
+        _serializedObject.Update();
+
+        EditorGUILayout.Separator();
+        EditorGUILayout.LabelField("Baked Data Profile", EditorStyles.boldLabel);
+        EditorUtil.DrawProperty(_serializedObject, nameof(profile));
+        EditorGUILayout.Separator();
+
+        // Input Directory
+        EditorGUILayout.LabelField("Baked Data Input Directory", EditorStyles.boldLabel);
+        EditorGUILayout.BeginHorizontal();
+        EditorUtil.DrawProperty(_serializedObject, nameof(inputDirectory));
+        if (GUILayout.Button("Browse", GUILayout.Width(75)))
+        {
+            var path = EditorUtility.OpenFolderPanel("Baked Data Input Directory", Application.dataPath, "BakedDataInput");
+            if (!string.IsNullOrEmpty(path))
+            {
+                inputDirectory = EditorUtil.GetAssetPath(path);
+            }
+        }
+        EditorGUILayout.EndHorizontal();
+        EditorGUILayout.Separator();
+
+        // Output Directory
+        EditorGUILayout.LabelField("Baked Data Output Directory", EditorStyles.boldLabel);
+        EditorGUILayout.BeginHorizontal();
+        EditorUtil.DrawProperty(_serializedObject, nameof(outputDirectory));
+        if (GUILayout.Button("Browse", GUILayout.Width(75)))
+        {
+            var path = EditorUtility.OpenFolderPanel("Baked Data Output Directory", Application.dataPath, "OverrideOutput");
+            if (!string.IsNullOrEmpty(path))
+            {
+                outputDirectory = EditorUtil.GetAssetPath(path);
+            }
+        }
+        EditorGUILayout.EndHorizontal();
+        EditorGUILayout.Separator();
+
+        DrawMessage();
+
+        _serializedObject.ApplyModifiedProperties();
+
+        return true;
+    }
+
+    private void OnWizardCreate()
+    {
+        // This method is called when the "Generate" button is clicked.
+        OnWizardOtherButton();
+    }
+
+    void OnWizardOtherButton()
+    {
+        var dataList = new List<BakedData>();
+        
+        // Failsafe: Check the directories actually exist first
+        if (!Directory.Exists(inputDirectory))
+        {
+            Debug.LogError($"Input directory does not exist: {inputDirectory}");
+            return;
+        }
+
+        if (!Directory.Exists(outputDirectory))
+        {
+            Debug.LogError($"Output directory does not exist: {outputDirectory}");
+            return;
+        }
+
+        // Step 1: Get a list of all audioclips in the input directory 
+        var clipIDList = AssetDatabase.FindAssets("t:AudioClip", new[] { inputDirectory });
+        //generate a list of all audioclip paths
+        List<string> audioClipPaths = clipIDList.Select(AssetDatabase.GUIDToAssetPath).ToList();
+
+        var audioClipCount = audioClipPaths.Count;
+        var bakedDataGenerated = 0;
+
+        // Step 2: For each audioclip, create a BakedData scriptable object with the defaultData set to the BakedData scriptable object
+        foreach (var audioClipPath in audioClipPaths)
+        {
+            
+            AudioClip clip = AssetDatabase.LoadAssetAtPath<AudioClip>(audioClipPath);
+            if (clip == null) continue;
+
+            // Generate the relative path and the output path for the bakedDataObject
+            var relativePath = audioClipPath[(inputDirectory.Length + 1)..];
+            var bakedDataPath = Path.Combine(outputDirectory, relativePath);
+            var bakedDataDirectory = Path.GetDirectoryName(bakedDataPath);
+            var bakedDataAssetName = Path.GetFileNameWithoutExtension(bakedDataPath) + ".asset";
+            if (bakedDataDirectory == null) continue;
+            var bakedDataAssetPath = Path.Combine(bakedDataDirectory, bakedDataAssetName);
+
+            // Ensure the output directory exists
+            if (!Directory.Exists(bakedDataDirectory))
+            {
+                Directory.CreateDirectory(bakedDataDirectory);
+            }
+
+            // Check if the BakedData asset already exists
+            var data = AssetDatabase.LoadAssetAtPath<BakedData>(bakedDataAssetPath);
+            if (data == null)
+            {
+                //Create the baked data
+                data = CreateInstance<BakedData>();
+                data.profile = profile;
+                data.audioClip = clip;
+                data.name = clip.name;
+                
+                var editor = (BakedDataEditor)Editor.CreateEditor(data, typeof(BakedDataEditor));
+                editor.Bake();
+                
+                AssetDatabase.CreateAsset(data, bakedDataAssetPath);
+                bakedDataGenerated++;
+                
+                var progress = (float)dataList.Count / audioClipPaths.Count;
+                var msg = $"Baking... {dataList.Count}/{audioClipPaths.Count}";
+                EditorUtility.DisplayProgressBar("uLipSync", msg, progress);
+            }
+            else
+            {
+                // Update the existing BakedData asset
+                data = CreateInstance<BakedData>();
+                data.profile = profile;
+                data.audioClip = clip;
+                data.name = clip.name;
+                
+                var editor = (BakedDataEditor)Editor.CreateEditor(data, typeof(BakedDataEditor));
+                editor.Bake();
+                
+                EditorUtility.SetDirty(data);
+                var progress = (float)dataList.Count / audioClipPaths.Count;
+                var msg = $"Baking... {dataList.Count}/{audioClipPaths.Count}";
+                EditorUtility.DisplayProgressBar("uLipSync", msg, progress);
+            }
+        }
+        
+        EditorUtility.ClearProgressBar();
+
+        // Save all changes to the asset database
+        AssetDatabase.SaveAssets();
+
+        // Step 5: Display a message with the number of BakedData scriptable objects found and the number of BakedData scriptable objects created
+        _message.Clear();
+        _message.AppendLine($"Found {audioClipCount} audioClips.");
+        _message.AppendLine($"Created {bakedDataGenerated} BakedData scriptable objects.");
+        Debug.Log(_message.ToString());
+
+        Repaint(); // Repaint the GUI to update the message
+    }
+
+    void DrawMessage()
+    {
+        if (_message.Length == 0) return;
+
+        EditorGUILayout.HelpBox(_message.ToString(), MessageType.Info);
+    }
+}

--- a/Assets/uLipSync/Editor/FixAssetMainObjectNames.cs
+++ b/Assets/uLipSync/Editor/FixAssetMainObjectNames.cs
@@ -1,0 +1,145 @@
+using System.IO;
+using UnityEngine;
+using UnityEditor;
+using UnityEditor.PackageManager;
+
+using PackageInfo = UnityEditor.PackageManager.PackageInfo;
+
+/// <summary>
+/// Adds a menu command to find and fix all assets that have mismatched main
+/// object names and file names. I.e., "Main Object Name '{0}' does not match
+/// filename '{1}'". This warning can appear after renaming from outside of
+/// Unity.
+/// <br /><br />
+///
+/// Read-only assets are ignored. Supports Undo. Has a dry-run mode to list
+/// the assets it would have modified in a full run.
+/// <br /><br />
+///
+/// This is essentially a way to do what Unity already does <see
+/// href="https://github.com/Unity-Technologies/UnityCsReference/blob/master/Editor/Mono/Inspector/Editor.cs#L1176">
+/// here</see> but in batch.
+/// </summary>
+public static class FixAssetMainObjectNames
+{
+    [MenuItem("Tools/Fix Asset Main Object Names")]
+    public static void FindAndFixAssets()
+    {
+        string dialogTitle =
+            ObjectNames.NicifyVariableName(nameof(FixAssetMainObjectNames));
+
+        // Prompt the user to do a dry run or the real thing. A dry run
+        // allows the user to verify nothing unwanted is affected.
+        int dialogResult =
+            EditorUtility.DisplayDialogComplex(
+                dialogTitle,
+                message: "Find and fix assets with incorrect main object " +
+                    "names?\n\nThis loads every asset in the project and " +
+                    "can be very slow in large projects.",
+                ok: "Dry Run",
+                cancel: "Cancel",
+                alt: "Fix All"
+            );
+
+        const int DialogResultOK = 0;
+        const int DialogResultCancel = 1;
+
+        if (dialogResult == DialogResultCancel)
+        {
+            return;
+        }
+
+        bool isDryRun = dialogResult == DialogResultOK;
+        if (isDryRun)
+        {
+            dialogTitle += " (Dry Run)";
+        }
+
+        // Find all assets
+        string[] allGuidsInProject = AssetDatabase.FindAssets("");
+
+        // List of types that don't complain in the inspector when their
+        // names are mismatched.
+        System.Type[] assetTypeBlacklist = new[]
+        {
+            typeof(Shader), // Shaders appear with mismatched names regularly. Even in official packages.
+            typeof(DefaultAsset),   // Folders with periods in them will have different names. This is OK.
+        };
+
+        bool didCancel = false;
+
+        try
+        {
+            int assetCount = allGuidsInProject.Length;
+            Debug.Log($"Starting scan over {assetCount} assets...");
+            for (int i = 0; i < assetCount; i++)
+            {
+                string assetGuid = allGuidsInProject[i];
+                string assetPath = AssetDatabase.GUIDToAssetPath(assetGuid);
+
+                Object asset = AssetDatabase.LoadAssetAtPath<Object>(assetPath);
+                
+                if(!asset || string.IsNullOrEmpty(asset.name)) continue;
+                string mainObjectName = asset.name ;
+                string expectedMainObjectName = Path.GetFileNameWithoutExtension(assetPath);
+
+                didCancel =
+                    EditorUtility.DisplayCancelableProgressBar(
+                        dialogTitle + $" - {i + 1} of {assetCount}",
+                        info: assetPath,
+                        progress: (float)(i + 1) / assetCount
+                    );
+
+                if (didCancel)
+                {
+                    // The user requested an early exit
+                    break;
+                }
+
+                int blacklistedTypeIndex =
+                    System.Array.IndexOf(assetTypeBlacklist, asset.GetType());
+
+                if (blacklistedTypeIndex >= 0)
+                {
+                    // Skip assets of blacklisted types. See array definition
+                    // above.
+                    continue;
+                }
+
+                if (mainObjectName == expectedMainObjectName)
+                {
+                    // Asset is already correct
+                    continue;
+                }
+
+                PackageInfo packageInfo = PackageInfo.FindForAssetPath(assetPath);
+                if (packageInfo != null &&
+                    packageInfo.source != PackageSource.Embedded &&
+                    packageInfo.source != PackageSource.Local)
+                {
+                    // Asset is read-only
+                    continue;
+                }
+
+                if (isDryRun)
+                {
+                    Debug.Log("Would fix: " + assetPath, asset);
+                }
+                else
+                {
+                    Undo.RecordObject(asset, dialogTitle);
+                    using SerializedObject serializedAsset = new SerializedObject(asset);
+                    asset.name = expectedMainObjectName;
+                    Debug.Log("Fixed: " + assetPath, asset);
+                }
+            }
+        }
+        finally
+        {
+            EditorUtility.ClearProgressBar();
+
+            Debug.Log(didCancel ? "Canceled." : "Finished.");
+        }
+    }
+
+}   // class FixAssetMainObjectNames

--- a/Assets/uLipSync/Editor/ULipSyncGameObjectEditor.cs
+++ b/Assets/uLipSync/Editor/ULipSyncGameObjectEditor.cs
@@ -1,0 +1,111 @@
+using UnityEngine;
+using UnityEditor;
+using UnityEditorInternal;
+
+namespace uLipSync
+{
+    [CustomEditor(typeof(ULipSyncGameObject))]
+    public class ULipSyncGameObjectEditor : Editor
+    {
+        private ULipSyncGameObject LipSyncGameObject => target as ULipSyncGameObject;
+        private ReorderableList _reorderableList;
+
+        public override void OnInspectorGUI()
+        {
+            serializedObject.Update();
+
+            if (EditorUtil.Foldout("LipSync Update Method", true))
+            {
+                ++EditorGUI.indentLevel;
+                EditorUtil.DrawProperty(serializedObject, nameof(LipSyncGameObject.updateMethod));
+                --EditorGUI.indentLevel;
+                EditorGUILayout.Separator();
+            }
+
+            if (EditorUtil.Foldout("Parameters", true))
+            {
+                ++EditorGUI.indentLevel;
+                DrawParameters();
+                --EditorGUI.indentLevel;
+                EditorGUILayout.Separator();
+            }
+
+
+            if (EditorUtil.Foldout("GameObjects", true))
+            {
+                ++EditorGUI.indentLevel;
+                DrawGameObjectReorderableList();
+                --EditorGUI.indentLevel;
+                EditorGUILayout.Separator();
+            }
+
+            serializedObject.ApplyModifiedProperties();
+        }
+
+        void DrawGameObjectReorderableList()
+        {
+            if (_reorderableList == null)
+            {
+                _reorderableList = new ReorderableList(LipSyncGameObject.gameObjects, typeof(MfccData));
+                _reorderableList.drawHeaderCallback = rect =>
+                {
+                    rect.xMin -= EditorGUI.indentLevel * 12f;
+                    EditorGUI.LabelField(rect, "Phoneme - Game Object Field");
+                };
+                _reorderableList.draggable = true;
+                _reorderableList.drawElementCallback = (rect, index, isActive, isFocused) =>
+                {
+                    EditorGUILayout.BeginHorizontal();
+                    EditorGUILayout.BeginVertical();
+                    var itemRect = new Rect(rect);
+                    DrawGameObjectItemList(itemRect, index);
+                    EditorGUILayout.EndVertical();
+                    /*
+                    var objectRect = new Rect(rect);
+                    objectRect.xMin = objectRect.xMax - 64f;
+                    objectRect.height = 64f;
+                    DrawGameObject(objectRect, index);*/
+                    EditorGUILayout.EndHorizontal();
+                };
+                _reorderableList.elementHeightCallback = index => 40f;
+            }
+
+            EditorGUILayout.Separator();
+            EditorGUILayout.BeginHorizontal();
+            var indent = EditorGUI.indentLevel * 12f;
+            EditorGUILayout.Space(indent, false);
+            EditorGUILayout.BeginVertical();
+            _reorderableList.DoLayoutList();
+            EditorGUILayout.EndVertical();
+            EditorGUILayout.EndHorizontal();
+        }
+
+        void DrawGameObjectItemList(Rect rect, int index)
+        {
+            rect.y += 2;
+            rect.height = EditorGUIUtility.singleLineHeight;
+            ULipSyncGameObject.GameObjectInfo item = LipSyncGameObject.gameObjects[index];
+            var singleLineHeight = EditorGUIUtility.singleLineHeight + EditorGUIUtility.standardVerticalSpacing;
+
+            var phonemeLabel = string.IsNullOrEmpty(item.phoneme) ? "Default" : "Phoneme";
+            item.phoneme = EditorGUI.TextField(rect, phonemeLabel, item.phoneme);
+
+            rect.y += singleLineHeight;
+
+            GameObject newGameObject =
+                (GameObject)EditorGUI.ObjectField(rect, "Game Object", item.gameObject, typeof(GameObject), true);
+            if (newGameObject != item.gameObject)
+            {
+                Undo.RecordObject(target, "Change Game Object");
+                item.gameObject = newGameObject;
+            }
+        }
+
+
+        void DrawParameters()
+        {
+            EditorUtil.DrawProperty(serializedObject, nameof(LipSyncGameObject.minVolume));
+            EditorUtil.DrawProperty(serializedObject, nameof(LipSyncGameObject.minDuration));
+        }
+    }
+}

--- a/Assets/uLipSync/Runtime/ULipSyncGameObject.cs
+++ b/Assets/uLipSync/Runtime/ULipSyncGameObject.cs
@@ -1,0 +1,157 @@
+using System.Collections.Generic;
+using System.Linq;
+using UnityEngine;
+
+namespace uLipSync
+{
+    public class ULipSyncGameObject : MonoBehaviour
+    {
+        [System.Serializable]
+        public class GameObjectInfo
+        {
+            public string phoneme;
+            public GameObject gameObject;
+        }
+
+        public UpdateMethod updateMethod = UpdateMethod.LateUpdate;
+        public List<GameObjectInfo> gameObjects = new();
+        public float minVolume = -2.5f;
+        [Range(0f, 1f)] public float minDuration = 0.1f;
+        private LipSyncInfo _info;
+        readonly List<string> _phonemeHistory = new();
+        private Dictionary<string, int> _phonemeCountTable = new();
+        private float _keepTimer;
+        private bool _lipSyncUpdated;
+        private float _volume = -100f;
+        private string _phoneme = "";
+        [SerializeField] private GameObject _initialGameObject;
+        
+        
+        
+        public GameObject InitialGameObject
+        {
+            get => _initialGameObject ? _initialGameObject : gameObject;
+            private set => _initialGameObject = value;
+        }
+
+        public void OnLipSyncUpdate(LipSyncInfo info)
+        {
+            _info = info;
+            _lipSyncUpdated = true;
+
+            if (updateMethod != UpdateMethod.LipSyncUpdateEvent) return;
+            UpdateLipSync();
+            Apply();
+        }
+
+        private void Update()
+        {
+            if (updateMethod != UpdateMethod.LipSyncUpdateEvent)
+            {
+                UpdateLipSync();
+            }
+
+            if (updateMethod == UpdateMethod.Update)
+            {
+                Apply();
+            }
+        }
+
+        private void LateUpdate()
+        {
+            if (updateMethod == UpdateMethod.LateUpdate)
+            {
+                Apply();
+            }
+        }
+
+        private void FixedUpdate()
+        {
+            if (updateMethod == UpdateMethod.FixedUpdate)
+            {
+                Apply();
+            }
+        }
+
+        private void UpdateLipSync()
+        {
+            UpdateVolume();
+            UpdateVowels();
+            _lipSyncUpdated = false;
+        }
+
+        private void UpdateVolume()
+        {
+            _volume = 0f;
+
+            if (!_lipSyncUpdated) return;
+
+            if (_info.rawVolume > 0f)
+            {
+                _volume = Mathf.Log10(_info.rawVolume);
+            }
+        }
+
+        private void UpdateVowels()
+        {
+            if (_lipSyncUpdated && _volume > minVolume)
+            {
+                _phonemeHistory.Add(_info.phoneme);
+            }
+            else
+            {
+                _phonemeHistory.Add("");
+            }
+
+            var minFrame = (int)Mathf.Max(minDuration / Time.deltaTime, 1f);
+            while (_phonemeHistory.Count > minFrame && _phonemeHistory.Count > 0)
+            {
+                _phonemeHistory.RemoveAt(0);
+            }
+
+            _phonemeCountTable.Clear();
+
+            for (int i = 0; i < _phonemeHistory.Count; i++)
+            {
+                _phonemeHistory[i] ??= "";
+            }
+
+            foreach (var key in _phonemeHistory)
+            {
+                if (_phonemeCountTable.ContainsKey(key))
+                {
+                    ++_phonemeCountTable[key];
+                }
+                else
+                {
+                    _phonemeCountTable.Add(key, 0);
+                }
+            }
+
+            _keepTimer += Time.deltaTime;
+            if (_keepTimer < minDuration) return;
+
+            var maxCount = 0;
+            var phoneme = "";
+            foreach (KeyValuePair<string, int> kv in _phonemeCountTable.Where(kv => kv.Value > maxCount))
+            {
+                phoneme = kv.Key;
+                maxCount = kv.Value;
+            }
+
+            if (_phoneme == phoneme) return;
+            _keepTimer = 0f;
+            _phoneme = phoneme;
+        }
+
+        private void Apply()
+        {
+            if (!InitialGameObject) return;
+            
+            foreach (GameObjectInfo info in gameObjects.Where(info => info.gameObject != null))
+            {
+                info.gameObject.SetActive(info.phoneme == _phoneme);
+            }
+        }
+    }
+}


### PR DESCRIPTION
**1. Enhanced Directory Wizard**
The existing wizard has a **_significant_** limitation: It only reads the children of a specified directory without replicating that directory's structure in the output. 
This oversight forces users to manually sort their baked data to match the hierarchy of the original audio clips, which is inefficient, prone to errors, and if your line count is high enough may lead to death from dehydration because of how long sorting them would take. My alternative wizard addresses this issue by cloning the directory hierarchy from input to output, ensuring that the structure of subfolders and their contents is preserved. 

**2. Game Object-based Lip Syncing for 2D Rigs**
I noticed a very noticeable gap in the current toolset for 2D lipsyncing, particularly for rigs that aren't sprite sheet-based (Believe it or not that's every single rig I use). uLipSyncTexture falls short in this case. One of Unity's only features that actually "just works" is the PSB import pipeline, which automatically slices sprites based on their boundaries, resulting in varying origins and sizes that aren't easily swappable. It also mirrors the layer structure when dragging the imported PSB into the editor. Therefore, all of your phonemes will already exist as individual game objects. So I created uLipSyncGameObject which is functionally similar to uLipSyncTexture, but works by just enabling and disabling the objects instead. 

I love this tool, so I hope these are useful additions. 