### PR TITLE
Optimize performance of LowPassFilter

### DIFF
--- a/Assets/uLipSync/Runtime/Core/Algorithm.cs
+++ b/Assets/uLipSync/Runtime/Core/Algorithm.cs
@@ -110,14 +110,11 @@ public static unsafe class Algorithm
             b[i] = 2f * cutoff * math.sin(ang) / ang;
         }
 
-        for (int i = 0; i < len; ++i)
+        for (int j = 0; j < bLen; ++j)
         {
-            for (int j = 0; j < bLen; ++j)
+            for (int i = j; i < len; ++i)
             {
-                if (i - j >= 0)
-                {
-                    data[i] += b[j] * tmp[i - j];
-                }
+                data[i] += b[j] * tmp[i - j];
             }
         }
     }


### PR DESCRIPTION
While profiling my wasm port [wLipSync](https://github.com/mrxz/wLipSync), I noticed that the low pass filter was the most expensive by a large margin. Luckily, the performance can be improved drastically with some minor changes. After testing if these performance gains are also possible in uLipSync with the Burst compiler, I can confirm that they are! :-)

This PR optimizes the `LowPassFilter` function by swapping the inner and outer loop and eliminating the if statement. The following table shows the performance improvement when measuring the entire algorithm (rough measurements):

|  | ms/it |
|---|-------|
| base | 3.22 ms  |
| swapping inner and outer loops | 1.48 ms |
| eliminating if statement | 0.82 ms |

There is one further optimization possible. Since the next step will be downsampling, the low pass filter can be applied only to the samples that are a multiple of `skip` in case of `DownSampleExact`, as the other samples are ignored anyway. But this requires more work to get the `skip` value used in `DownSample` before calling `LowPassFilter`. For reference, here's the commit implementing it: https://github.com/mrxz/wLipSync/commit/5ded0c490387354f0dffc19ff04411c8cfc15ed5