### PR TITLE
Prevent crash when _rawInputData is not created

### DIFF
--- a/Assets/uLipSync/Runtime/uLipSync.cs
+++ b/Assets/uLipSync/Runtime/uLipSync.cs
@@ -363,10 +363,10 @@ public class uLipSync : MonoBehaviour
 
     public void OnDataReceived(float[] input, int channels)
     {
-        if (_rawInputData.Length == 0) return;
-
         lock (_lockObject)
         {
+            if (!_rawInputData.IsCreated || _rawInputData.Length == 0) return;
+            
             int n = _rawInputData.Length;
             _index = _index % n;
             for (int i = 0; i < input.Length; i += channels) 


### PR DESCRIPTION
Our app saw repeated bad memory access crashes that occurred when accessing `_rawInputData`. When we investigated, we saw that `_rawInputData` is usually referenced within the `lock (_lockObject)`, but was not in the `OnDataReceived` method.

This PR moves access of `_rawInputData` to within the `lock (_lockObject)`, and guards that the array represents valid memory before accessing data within it. Adopting this change locally fixed our crash.